### PR TITLE
feat 루틴을 추가하는 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 .DS_Store
+MyPlayground.playground

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
 - trailing_whitespace
 - type_name
+- type_body_length
 included:
   - Routine
 excluded:

--- a/Routine.xcodeproj/project.pbxproj
+++ b/Routine.xcodeproj/project.pbxproj
@@ -8,6 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		188300C2296FA71600E418DB /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188300C1296FA71600E418DB /* UITableView.swift */; };
+		188508022977A2BF005B7BAB /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188508012977A2BF005B7BAB /* Task.swift */; };
+		188508132977B98D005B7BAB /* Routine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188508122977B98D005B7BAB /* Routine.swift */; };
+		188508152977B993005B7BAB /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188508142977B993005B7BAB /* Todo.swift */; };
+		1885081C2977F4C0005B7BAB /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885081B2977F4C0005B7BAB /* ListViewModel.swift */; };
+		1885081E2977F53A005B7BAB /* RoutineManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885081D2977F53A005B7BAB /* RoutineManager.swift */; };
+		188508202977F5CF005B7BAB /* TodoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885081F2977F5CF005B7BAB /* TodoManager.swift */; };
+		1885082229784FC9005B7BAB /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885082129784FC9005B7BAB /* Date.swift */; };
+		1888269829794BDF00B6523A /* ListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1888269729794BDF00B6523A /* ListViewControllerTests.swift */; };
+		188826AE29794C2100B6523A /* ListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188826AD29794C2100B6523A /* ListViewModelTests.swift */; };
+		188826B629796D6E00B6523A /* CreateRoutineViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188826B529796D6E00B6523A /* CreateRoutineViewControllerTests.swift */; };
+		188826B729796D6E00B6523A /* CreateRoutineViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188826B529796D6E00B6523A /* CreateRoutineViewControllerTests.swift */; };
 		188BF94329724E3B0057C250 /* CreateRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */; };
 		18B6265C296F111200BDAB50 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B6265B296F111200BDAB50 /* UIColor.swift */; };
 		18B6265E296F118F00BDAB50 /* ButtonRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B6265D296F118F00BDAB50 /* ButtonRoutineTableViewCell.swift */; };
@@ -29,8 +40,37 @@
 		18C652AD2962A0C400EEB927 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 18C652AC2962A0C400EEB927 /* .swiftlint.yml */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		1888269B29794BDF00B6523A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 18C6528B29628DDD00EEB927 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18C6529229628DDD00EEB927;
+			remoteInfo = Routine;
+		};
+		188826A829794BF800B6523A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 18C6528B29628DDD00EEB927 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18C6529229628DDD00EEB927;
+			remoteInfo = Routine;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		188300C1296FA71600E418DB /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
+		188508012977A2BF005B7BAB /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
+		188508122977B98D005B7BAB /* Routine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routine.swift; sourceTree = "<group>"; };
+		188508142977B993005B7BAB /* Todo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
+		1885081B2977F4C0005B7BAB /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		1885081D2977F53A005B7BAB /* RoutineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineManager.swift; sourceTree = "<group>"; };
+		1885081F2977F5CF005B7BAB /* TodoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoManager.swift; sourceTree = "<group>"; };
+		1885082129784FC9005B7BAB /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		1888269729794BDF00B6523A /* ListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewControllerTests.swift; sourceTree = "<group>"; };
+		188826AD29794C2100B6523A /* ListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModelTests.swift; sourceTree = "<group>"; };
+		188826B529796D6E00B6523A /* CreateRoutineViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoutineViewControllerTests.swift; sourceTree = "<group>"; };
+		188826C32979825E00B6523A /* RoutineUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = RoutineUITests.xctest; path = "/Users/apple/Desktop/swift/Routine/build/Debug-iphoneos/RoutineUITests.xctest"; sourceTree = "<absolute>"; };
+		188826C42979825E00B6523A /* RoutineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = RoutineTests.xctest; path = /Users/apple/Desktop/swift/Routine/build/Debug/RoutineTests.xctest; sourceTree = "<absolute>"; };
 		188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoutineViewController.swift; sourceTree = "<group>"; };
 		18B6265B296F111200BDAB50 /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		18B6265D296F118F00BDAB50 /* ButtonRoutineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ButtonRoutineTableViewCell.swift; path = Cell/ButtonRoutineTableViewCell.swift; sourceTree = "<group>"; };
@@ -54,6 +94,20 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1888269229794BDF00B6523A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		188826A129794BF700B6523A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18C6529029628DDD00EEB927 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -65,6 +119,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1888269629794BDF00B6523A /* RoutineUITests */ = {
+			isa = PBXGroup;
+			children = (
+				1888269729794BDF00B6523A /* ListViewControllerTests.swift */,
+				188826B529796D6E00B6523A /* CreateRoutineViewControllerTests.swift */,
+			);
+			path = RoutineUITests;
+			sourceTree = "<group>";
+		};
+		188826A529794BF800B6523A /* RoutineTests */ = {
+			isa = PBXGroup;
+			children = (
+				188826AD29794C2100B6523A /* ListViewModelTests.swift */,
+			);
+			path = RoutineTests;
+			sourceTree = "<group>";
+		};
 		18B6265A296F0F5600BDAB50 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +174,7 @@
 				18C363F4296D828400745400 /* UICollectionViewCell.swift */,
 				18C36401296DBFFC00745400 /* CALayer.swift */,
 				188300C1296FA71600E418DB /* UITableView.swift */,
+				1885082129784FC9005B7BAB /* Date.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -113,6 +185,8 @@
 				18C652AC2962A0C400EEB927 /* .swiftlint.yml */,
 				18C6529529628DDD00EEB927 /* Routine */,
 				18C363C6296D091B00745400 /* Routine.app */,
+				1888269629794BDF00B6523A /* RoutineUITests */,
+				188826A529794BF800B6523A /* RoutineTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,6 +202,12 @@
 				18C6529F29628DDE00EEB927 /* Assets.xcassets */,
 				18C652A129628DDE00EEB927 /* LaunchScreen.storyboard */,
 				18C652A429628DDE00EEB927 /* Info.plist */,
+				188508012977A2BF005B7BAB /* Task.swift */,
+				188508122977B98D005B7BAB /* Routine.swift */,
+				1885081B2977F4C0005B7BAB /* ListViewModel.swift */,
+				1885081D2977F53A005B7BAB /* RoutineManager.swift */,
+				1885081F2977F5CF005B7BAB /* TodoManager.swift */,
+				188508142977B993005B7BAB /* Todo.swift */,
 			);
 			path = Routine;
 			sourceTree = "<group>";
@@ -135,6 +215,44 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1888269429794BDF00B6523A /* RoutineUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1888269D29794BDF00B6523A /* Build configuration list for PBXNativeTarget "RoutineUITests" */;
+			buildPhases = (
+				1888269129794BDF00B6523A /* Sources */,
+				1888269229794BDF00B6523A /* Frameworks */,
+				1888269329794BDF00B6523A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1888269C29794BDF00B6523A /* PBXTargetDependency */,
+			);
+			name = RoutineUITests;
+			packageProductDependencies = (
+			);
+			productName = RoutineUITests;
+			productReference = 188826C32979825E00B6523A /* RoutineUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		188826A329794BF700B6523A /* RoutineTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 188826AA29794BF800B6523A /* Build configuration list for PBXNativeTarget "RoutineTests" */;
+			buildPhases = (
+				188826A029794BF700B6523A /* Sources */,
+				188826A129794BF700B6523A /* Frameworks */,
+				188826A229794BF700B6523A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				188826A929794BF800B6523A /* PBXTargetDependency */,
+			);
+			name = RoutineTests;
+			productName = RoutineTests;
+			productReference = 188826C42979825E00B6523A /* RoutineTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		18C6529229628DDD00EEB927 /* Routine */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 18C652A729628DDE00EEB927 /* Build configuration list for PBXNativeTarget "Routine" */;
@@ -166,6 +284,14 @@
 				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					1888269429794BDF00B6523A = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = 18C6529229628DDD00EEB927;
+					};
+					188826A329794BF700B6523A = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = 18C6529229628DDD00EEB927;
+					};
 					18C6529229628DDD00EEB927 = {
 						CreatedOnToolsVersion = 14.0;
 					};
@@ -188,11 +314,27 @@
 			projectRoot = "";
 			targets = (
 				18C6529229628DDD00EEB927 /* Routine */,
+				1888269429794BDF00B6523A /* RoutineUITests */,
+				188826A329794BF700B6523A /* RoutineTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1888269329794BDF00B6523A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		188826A229794BF700B6523A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18C6529129628DDD00EEB927 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -227,30 +369,68 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1888269129794BDF00B6523A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1888269829794BDF00B6523A /* ListViewControllerTests.swift in Sources */,
+				188826B729796D6E00B6523A /* CreateRoutineViewControllerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		188826A029794BF700B6523A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				188826AE29794C2100B6523A /* ListViewModelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18C6528F29628DDD00EEB927 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1885082229784FC9005B7BAB /* Date.swift in Sources */,
 				18B6265C296F111200BDAB50 /* UIColor.swift in Sources */,
 				18B62669296F11F200BDAB50 /* TextRoutineTableViewCell.swift in Sources */,
 				18C6529729628DDD00EEB927 /* AppDelegate.swift in Sources */,
 				18C363E7296D4D2700745400 /* CircleTextView.swift in Sources */,
+				188508132977B98D005B7BAB /* Routine.swift in Sources */,
 				18C363CF296D0C4F00745400 /* ListViewController.swift in Sources */,
 				18C6529929628DDD00EEB927 /* SceneDelegate.swift in Sources */,
 				18C363F5296D828400745400 /* UICollectionViewCell.swift in Sources */,
 				18C363D7296D100200745400 /* MyInfoViewController.swift in Sources */,
+				188508202977F5CF005B7BAB /* TodoManager.swift in Sources */,
 				18B6265E296F118F00BDAB50 /* ButtonRoutineTableViewCell.swift in Sources */,
 				188300C2296FA71600E418DB /* UITableView.swift in Sources */,
+				188826B629796D6E00B6523A /* CreateRoutineViewControllerTests.swift in Sources */,
 				18B6266E296F123800BDAB50 /* TodoListTableViewCell.swift in Sources */,
 				18B6266A296F11F200BDAB50 /* DailyCollectionViewCell.swift in Sources */,
 				18C36402296DBFFC00745400 /* CALayer.swift in Sources */,
+				1885081E2977F53A005B7BAB /* RoutineManager.swift in Sources */,
 				18C363DB296D105100745400 /* SettingViewController.swift in Sources */,
 				18C363D3296D0D0900745400 /* TabBarController.swift in Sources */,
+				188508022977A2BF005B7BAB /* Task.swift in Sources */,
+				1885081C2977F4C0005B7BAB /* ListViewModel.swift in Sources */,
 				188BF94329724E3B0057C250 /* CreateRoutineViewController.swift in Sources */,
+				188508152977B993005B7BAB /* Todo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1888269C29794BDF00B6523A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 18C6529229628DDD00EEB927 /* Routine */;
+			targetProxy = 1888269B29794BDF00B6523A /* PBXContainerItemProxy */;
+		};
+		188826A929794BF800B6523A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 18C6529229628DDD00EEB927 /* Routine */;
+			targetProxy = 188826A829794BF800B6523A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		18C652A129628DDE00EEB927 /* LaunchScreen.storyboard */ = {
@@ -264,6 +444,88 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1888269E29794BDF00B6523A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = KD.RoutineUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Routine;
+			};
+			name = Debug;
+		};
+		1888269F29794BDF00B6523A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = KD.RoutineUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Routine;
+			};
+			name = Release;
+		};
+		188826AB29794BF800B6523A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
+				ENABLE_TESTABILITY = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = KD.RoutineTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Routine.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Routine";
+			};
+			name = Debug;
+		};
+		188826AC29794BF800B6523A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
+				ENABLE_TESTABILITY = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = KD.RoutineTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Routine.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Routine";
+			};
+			name = Release;
+		};
 		18C652A529628DDE00EEB927 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -386,6 +648,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2FY7M8J988;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Routine/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -414,6 +677,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2FY7M8J988;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Routine/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -437,6 +701,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1888269D29794BDF00B6523A /* Build configuration list for PBXNativeTarget "RoutineUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1888269E29794BDF00B6523A /* Debug */,
+				1888269F29794BDF00B6523A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		188826AA29794BF800B6523A /* Build configuration list for PBXNativeTarget "RoutineTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				188826AB29794BF800B6523A /* Debug */,
+				188826AC29794BF800B6523A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		18C6528E29628DDD00EEB927 /* Build configuration list for PBXProject "Routine" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Routine.xcodeproj/xcuserdata/apple.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Routine.xcodeproj/xcuserdata/apple.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,6 +4,48 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
+		<key>MyPlayground (Playground) 1.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>5</integer>
+		</dict>
+		<key>MyPlayground (Playground) 2.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>6</integer>
+		</dict>
+		<key>MyPlayground (Playground) 3.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>7</integer>
+		</dict>
+		<key>MyPlayground (Playground) 4.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>8</integer>
+		</dict>
+		<key>MyPlayground (Playground) 5.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>9</integer>
+		</dict>
+		<key>MyPlayground (Playground).xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
 		<key>Routine.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
@@ -14,7 +56,7 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>2</integer>
 		</dict>
 		<key>SnapKitPlayground (Playground) 2.xcscheme</key>
 		<dict>
@@ -50,6 +92,29 @@
 			<false/>
 			<key>orderHint</key>
 			<integer>1</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>188508062977A2DA005B7BAB</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>1888269429794BDF00B6523A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>188826A329794BF700B6523A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>18C6529229628DDD00EEB927</key>
+		<dict>
+			<key>primary</key>
+			<true/>
 		</dict>
 	</dict>
 </dict>

--- a/Routine/Extension/Date.swift
+++ b/Routine/Extension/Date.swift
@@ -1,0 +1,34 @@
+//
+//  Date.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/19.
+//
+
+import Foundation
+
+extension Date {
+    var timeToString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:ss"
+        return formatter.string(from: self)
+    }
+    
+    var dateToString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        return formatter.string(from: self)
+    }
+    
+    var year: Int {
+        return Calendar.current.component(.year, from: self)
+    }
+    
+    var month: Int {
+        return Calendar.current.component(.month, from: self)
+    }
+    
+    var day: Int {
+        return Calendar.current.component(.day, from: self)
+    }
+}

--- a/Routine/ListViewModel.swift
+++ b/Routine/ListViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  TaskListViewModel.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+final class ListViewModel {
+    private let routineManager: RoutineManager = RoutineManager()
+    private let todoManager: TodoManager = TodoManager()
+    
+    func create(routine: Routine) {
+        routineManager.create(routine)
+    }
+    
+    func append(routinTask: RoutineTask) {
+        routineManager.append(routinTask)
+    }
+    
+    func append(todo: Todo) {
+        todoManager.append(todo)
+    }
+    
+    func fetch(routineIdentifier: UUID) -> Routine? {
+        return routineManager.fetch(routineIdentifier)
+    }
+    
+    func fetchTask(todoIdentifier: UUID) -> Task? {
+        return todoManager.fecth(todoIdentifier)
+    }
+    
+    func fetchTask(routineTask: RoutineTask) -> RoutineTask? {
+        return routineManager.fetch(routineTask: routineTask)
+    }
+    
+    func fetchAllTask(to date: Date) -> [Task] {
+        var tasks = routineManager.fetchAllTask(to: date)
+        tasks.append(contentsOf: todoManager.fetchAllTask(to: date))
+        return tasks
+    }
+}

--- a/Routine/Routine.swift
+++ b/Routine/Routine.swift
@@ -1,0 +1,101 @@
+//
+//  Routine.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+enum DayOfWeek: String, CaseIterable {
+    case mon = "월"
+    case tue = "화"
+    case wed = "수"
+    case thu = "목"
+    case fir = "금"
+    case sat = "토"
+    case sun = "일"
+    
+    static let allCases: [DayOfWeek] = [.mon, .tue, .wed, .thu, .fir, .sat, .sun]
+}
+
+protocol RoutineTask: Task {
+    var routineIdentifier: UUID { get }
+}
+
+//TODO: 제네릭 타입으로 바꿔서 원하는 루틴 타입에 맞게 myTaskList의 타입을 정할수 있게 변경하기
+struct Routine {
+    let identifier: UUID = UUID()
+    var description: String
+    var dayOfWeek: [DayOfWeek] = [.mon, .tue, .wed, .thu, .fir, .sat, .sun]
+    var startDate: Date = Date()
+    var endDate: Date?
+    var notificationTime: Date?
+    var type: RoutineType = .check
+    var myTaskList: [RoutineTask] = []
+    
+    //TODO: RotineTask의 타입을 제네릭으로 설정후 그에 맞는 타입으로 Task를 생성
+    func createTask(date: Date) -> RoutineTask {
+        return RoutineCheckTask(routine: self, taskDate: date )
+    }
+}
+
+struct RoutineTextTask: RoutineTask {
+    var routineIdentifier: UUID
+    var identifier: UUID = UUID()
+    var descrpition: String
+    var text: String {
+        didSet {
+            isDone = false == text.isEmpty
+        }
+    }
+    var taskDate: Date
+    var isDone: Bool = false
+    
+    init(routine: Routine, text: String, taskDate: Date) {
+        self.routineIdentifier = routine.identifier
+        self.descrpition = routine.description
+        self.text = text
+        self.taskDate = taskDate
+    }
+}
+
+struct RoutineCountTask: RoutineTask {
+    var routineIdentifier: UUID
+    var identifier: UUID = UUID()
+    var descrpition: String
+    private var description: String
+    var text: String {
+        return description + "\(count)"
+    }
+    var goal: Int
+    var count: Int = 0 {
+        didSet {
+            if goal == count { isDone = true }
+        }
+    }
+    var taskDate: Date
+    var isDone: Bool = false
+    
+    init(routine: Routine, description: String, goal: Int, taskDate: Date) {
+        self.routineIdentifier = routine.identifier
+        self.descrpition = routine.description
+        self.description = description
+        self.goal = goal
+        self.taskDate = taskDate
+    }
+}
+
+struct RoutineCheckTask: RoutineTask {
+    var routineIdentifier: UUID
+    var identifier: UUID = UUID()
+    var descrpition: String
+    var taskDate: Date
+    var isDone: Bool = false
+    
+    init(routine: Routine, taskDate: Date) {
+        self.routineIdentifier = routine.identifier
+        self.descrpition = routine.description
+        self.taskDate = taskDate
+    }
+}

--- a/Routine/RoutineManager.swift
+++ b/Routine/RoutineManager.swift
@@ -1,0 +1,63 @@
+//
+//  RoutineManager.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+class RoutineManager {
+    static var routines: [Routine] = []
+    var routineCount: Int {
+        return RoutineManager.routines.count
+    }
+    
+    func create(_ routine: Routine) {
+        RoutineManager.routines.append(routine)
+    }
+    
+    func append(_ task: RoutineTask) {
+        guard let index = RoutineManager.routines.firstIndex( where: { $0.identifier == task.routineIdentifier }) else {
+            print("Routine does not exist")
+            return
+        }
+        RoutineManager.routines[index].myTaskList.append(task)
+    }
+    
+    func update(_ task: RoutineTask) {
+        guard let routineIndex = RoutineManager.routines.firstIndex( where: { $0.identifier == task.routineIdentifier }) else {
+            print("Routine does not exist")
+            return
+        }
+        let myTaskList = RoutineManager.routines[routineIndex].myTaskList
+        guard let taskIndex = myTaskList.firstIndex(where: { $0.identifier == task.identifier }) else {
+            print("RoutineTask does not exist")
+            return
+        }
+        RoutineManager.routines[routineIndex].myTaskList[taskIndex] = task
+    }
+    
+    func fetch(_ identifier: UUID) -> Routine? {
+        return RoutineManager.routines.first(where: { $0.identifier == identifier })
+    }
+    
+    func fetch(routineTask: RoutineTask) -> RoutineTask? {
+        guard let routine = RoutineManager.routines.first(where: { $0.identifier == routineTask.routineIdentifier }) else {
+            print("routine does not exits")
+            return nil
+        }
+    return routine.myTaskList.first(where: { $0.identifier == routineTask.identifier })
+    }
+    
+    func fetchAllTask(to date: Date) -> [Task] {
+        var tasks = [Task]()
+        let calendar = Calendar.current
+        print(RoutineManager.routines)
+        RoutineManager.routines.forEach { routine in
+            let routineTask = routine.myTaskList.first( where: { calendar.isDate(date, equalTo: $0.taskDate, toGranularity: .day) })
+            tasks.append(routineTask ?? routine.createTask(date: date))
+        }
+        return tasks
+    }
+}

--- a/Routine/SceneDelegate.swift
+++ b/Routine/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
         window.backgroundColor = .white
-        window.rootViewController = CreateRoutineViewController()
+        window.rootViewController = TabBarController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/Routine/TabBarController.swift
+++ b/Routine/TabBarController.swift
@@ -23,7 +23,7 @@ class TabBarController: UITabBarController {
     }
     
     private func viewControllerSetting() {
-        let vc1 = UINavigationController(rootViewController: ListViewController())
+        let vc1 = UINavigationController(rootViewController: ListViewController(viewModel: ListViewModel()))
         let vc2 = UINavigationController(rootViewController: MyInfoViewController())
         let vc3 = UINavigationController(rootViewController: SettingViewController())
 

--- a/Routine/Task.swift
+++ b/Routine/Task.swift
@@ -1,0 +1,15 @@
+//
+//  Task.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+protocol Task {
+    var identifier: UUID { get }
+    var descrpition: String { get }
+    var taskDate: Date { get set }
+    var isDone: Bool { get set }
+}

--- a/Routine/Todo.swift
+++ b/Routine/Todo.swift
@@ -1,0 +1,15 @@
+//
+//  Todo.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+struct Todo: Task {
+    var identifier: UUID = UUID()
+    var descrpition: String
+    var taskDate: Date
+    var isDone: Bool = false
+}

--- a/Routine/TodoManager.swift
+++ b/Routine/TodoManager.swift
@@ -1,0 +1,34 @@
+//
+//  TodoManager.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/18.
+//
+
+import Foundation
+
+class TodoManager {
+    private var todoList: [Todo] = []
+    var todoCount: Int {
+        return todoList.count
+    }
+    
+    func append(_ todo: Todo) {
+        todoList.append(todo)
+    }
+    
+    func fecth(_ identifier: UUID) -> Todo? {
+        return todoList.first(where: { $0.identifier == identifier })
+    }
+    
+    func fetchAllTask(to date: Date) -> [Task] {
+        var tasks = [Task]()
+        let calendar = Calendar.current
+        todoList.forEach { todo in
+            if calendar.isDate(date, equalTo: todo.taskDate, toGranularity: .day) {
+                tasks.append(todo)
+            }
+        }
+        return tasks
+    }
+}

--- a/Routine/View/CircleTextView.swift
+++ b/Routine/View/CircleTextView.swift
@@ -22,6 +22,22 @@ class CircleTextView: UIView {
             self.backgroundColor = isToday ? UIColor(hex: 0xD9D9D9) : .white.withAlphaComponent(0.0)
         }
     }
+    var isSelected: Bool = true {
+        didSet {
+            if isSelected {
+                self.backgroundColor = .mainColor
+                dailyLabel.textColor = .black
+            } else {
+                self.backgroundColor = .secondaryColor
+                dailyLabel.textColor = .white
+            }
+        }
+    }
+    var dayOfWeek: DayOfWeek = .mon {
+        didSet {
+            dailyLabel.text = dayOfWeek.rawValue
+        }
+    }
     var date: String = "1" {
         didSet {
             dailyLabel.text = date
@@ -51,6 +67,10 @@ class CircleTextView: UIView {
     
     override func draw(_ rect: CGRect) {
         layer.cornerRadius = frame.height / 2
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.isSelected = !self.isSelected
     }
 
 }

--- a/RoutineTests/ListViewModelTests.swift
+++ b/RoutineTests/ListViewModelTests.swift
@@ -1,0 +1,86 @@
+//
+//  ListViewModelTests.swift
+//  RoutineTests
+//
+//  Created by 김도현 on 2023/01/19.
+//
+
+import XCTest
+@testable import Routine
+
+final class TaskListViewModelTests: XCTestCase {
+    
+    var sut: ListViewModel!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = ListViewModel()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func testRoutine_추가시_정보가_저장됨() {
+        let routine = Routine(description: "title")
+        sut.create(routine: routine)
+        if let fetchRoutine = sut.fetch(routineIdentifier: routine.identifier) {
+            XCTAssertEqual(fetchRoutine.identifier, routine.identifier, "루틴이 저장되지 않음")
+            return
+        }
+        XCTAssert(false , "루틴 값이 nil")
+    }
+    
+    func testTodo_추가시_정보가_저장됨() {
+        let todo = Todo(descrpition: "Test", taskDate: Date())
+        sut.append(todo: todo)
+        if let fetchTodo = sut.fetchTask(todoIdentifier: todo.identifier) {
+            XCTAssertEqual(fetchTodo.identifier, todo.identifier)
+            return
+        }
+        XCTAssert(false, "투두 값이 nil")
+    }
+    
+    func test루틴_할일_성공시_저장() {
+        let routine = Routine(description: "TestRoutine")
+        sut.create(routine: routine)
+        let routineTask = RoutineTextTask(routine: routine, text: "TestTask", taskDate: Date())
+        sut.append(routinTask: routineTask)
+        if let fetchTask = sut.fetchTask(routineTask: routineTask) {
+            XCTAssertEqual(fetchTask.identifier, routineTask.identifier, "루틴 작업을 제대로 가져오지 못함")
+            return
+        }
+        XCTAssert(false, "루틴 작업이 nil")
+    }
+    
+    func test맞는날짜에_대한_할일들_불러오기() {
+        let routine = Routine(description: "TestRoutine")
+        sut.create(routine: routine)
+        
+        let todo = Todo(descrpition: "TestTodo", taskDate: Date())
+        sut.append(todo: todo)
+        
+        let routineTask = RoutineTextTask(routine: routine, text: "TestTask", taskDate: Date())
+        sut.append(routinTask: routineTask)
+        let tasks = sut.fetchAllTask(to: Date())
+        
+        XCTAssertEqual(tasks.count, 2, "오늘 해야할 일들을 가져오지 못함")
+        XCTAssertEqual(tasks.filter({ $0.identifier == routineTask.identifier }).isEmpty, false, "오늘 할일을 가져오지 못함")
+    }
+    
+    func test오늘_할일을_가져올때_어제_할일을_가져오면_안됨() {
+        let routine = Routine(description: "TestRoutine")
+        sut.create(routine: routine)
+        
+        if let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) {
+            let yesterdayRoutineTask = RoutineTextTask(routine: routine, text: "TestYesterday", taskDate: yesterday)
+            sut.append(routinTask: yesterdayRoutineTask)
+        } else {
+            XCTAssert(false, "yesterday is nil")
+        }
+        let fetchTasks = sut.fetchAllTask(to: Date())
+        XCTAssertEqual(fetchTasks.count, 0, "오늘 할일만 가져와야 하는데 어제 할일을 가져옴")
+    }
+    
+}

--- a/RoutineUITests/CreateRoutineViewControllerTests.swift
+++ b/RoutineUITests/CreateRoutineViewControllerTests.swift
@@ -1,0 +1,35 @@
+//
+//  CreateRoutineViewControllerTests.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/01/19.
+//
+
+import XCTest
+
+final class CreateRoutineViewControllerTests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        app = XCUIApplication()
+        app.launch()
+        continueAfterFailure = false
+        app.buttons["리스트 추가 +"].tap()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func test_루틴_제목을_입력해야_저장버튼이_활성화됨() {
+        let doneButton = app.buttons["완료"]
+        let afterButton = app.buttons["리스트 추가 +"]
+        XCTAssertFalse(afterButton.exists, "루탄 제목을 입력안해도 저장 버튼 활성화")
+        let textfield = app.textFields["나의 루틴을 입력해주세요."]
+        textfield.tap()
+        app.typeText("Test")
+        doneButton.tap()
+        XCTAssert(afterButton.exists, "루틴 제목을 입력해도 저장 버튼이 활성화 되지 않음")
+    }
+}

--- a/RoutineUITests/ListViewControllerTests.swift
+++ b/RoutineUITests/ListViewControllerTests.swift
@@ -1,0 +1,34 @@
+//
+//  RoutineUITests.swift
+//  RoutineUITests
+//
+//  Created by 김도현 on 2023/01/19.
+//
+
+import XCTest
+
+final class ListViewControllerTests: XCTestCase {
+    
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        app = XCUIApplication()
+        app.launch()
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func test셀이_오늘_날짜로_되어있음() throws {
+        let cells = app.collectionViews.cells
+        let centerCell = cells.element(boundBy: cells.count/2)
+        XCTAssertEqual(centerCell.isSelected, true, "오늘 날짜에 맞는 셀이 선택됨")
+    }
+    
+    func test리스트추가버튼_클릭시_새로운_루틴을_추가하는_화면으로_전환됨() {
+        app.buttons["리스트 추가 +"].tap()
+        XCTAssert(app.staticTexts["루틴 이름"].exists, "루틴 생성 화면으로 넘어가지 못함")
+    }
+}


### PR DESCRIPTION
## 루틴을 추가하는 기능    

## 작업내용    
- RoutineManager가 루틴을 만들고 그 루틴을 ListViewModel에게 넘겨 받아 ViewContorller에게 뿌려주는 형태로 설계함     
- 루틴과 투두의 역할이 약간의 차이가 있기때문에 RoutineManager와 TodoManager를 따로 만듦     
- 화면에 보여질때에는 Task라는 프로토콜을 통해 한번에 ViewController에 전해주는 방식     

● ListViewModel의 유닛테스트 Create, Update 작성
▲ ListViewController와 CreateRoutineViewController의 UITest 작성중이지만 완성은 아님
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-01-20 at 02 33 38](https://user-images.githubusercontent.com/71269216/213521010-1bf9efad-913b-4def-9841-c1e6c0fc7a34.gif)
