### PR TITLE
Refactor Routine 프로토콜 클래스로 변경

### DIFF
--- a/Routine.xcodeproj/project.pbxproj
+++ b/Routine.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		18B62669296F11F200BDAB50 /* TextRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B62667296F11F200BDAB50 /* TextRoutineTableViewCell.swift */; };
 		18B6266A296F11F200BDAB50 /* DailyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B62668296F11F200BDAB50 /* DailyCollectionViewCell.swift */; };
 		18B6266E296F123800BDAB50 /* TodoListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B6266D296F123800BDAB50 /* TodoListTableViewCell.swift */; };
+		18B7936029FB9D5E00C2A472 /* MyRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B7935F29FB9D5E00C2A472 /* MyRoutineTableViewCell.swift */; };
+		18B7936229FBAEEC00C2A472 /* MyRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B7936129FBAEEC00C2A472 /* MyRoutineViewController.swift */; };
 		18C363CF296D0C4F00745400 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C363CD296D0C4F00745400 /* ListViewController.swift */; };
 		18C363D3296D0D0900745400 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C363D1296D0D0900745400 /* TabBarController.swift */; };
 		18C363D7296D100200745400 /* MyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C363D5296D100200745400 /* MyInfoViewController.swift */; };
@@ -102,6 +104,8 @@
 		18B62667296F11F200BDAB50 /* TextRoutineTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextRoutineTableViewCell.swift; path = Cell/TextRoutineTableViewCell.swift; sourceTree = "<group>"; };
 		18B62668296F11F200BDAB50 /* DailyCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DailyCollectionViewCell.swift; path = Cell/DailyCollectionViewCell.swift; sourceTree = "<group>"; };
 		18B6266D296F123800BDAB50 /* TodoListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TodoListTableViewCell.swift; path = Cell/TodoListTableViewCell.swift; sourceTree = "<group>"; };
+		18B7935F29FB9D5E00C2A472 /* MyRoutineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRoutineTableViewCell.swift; sourceTree = "<group>"; };
+		18B7936129FBAEEC00C2A472 /* MyRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRoutineViewController.swift; sourceTree = "<group>"; };
 		18C363C6296D091B00745400 /* Routine.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Routine.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C363CD296D0C4F00745400 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		18C363D1296D0D0900745400 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
@@ -171,6 +175,7 @@
 				18B6266D296F123800BDAB50 /* TodoListTableViewCell.swift */,
 				18A9B24A299B8195006C370D /* CountRoutineTableViewCell.swift */,
 				18AB794B29C9BB680080A0DE /* UITaskTableViewCell.swift */,
+				18B7935F29FB9D5E00C2A472 /* MyRoutineTableViewCell.swift */,
 			);
 			name = Cell;
 			sourceTree = "<group>";
@@ -184,6 +189,7 @@
 				18C363D9296D105100745400 /* SettingViewController.swift */,
 				188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */,
 				18A9B24C299B9231006C370D /* TextAddViewController.swift */,
+				18B7936129FBAEEC00C2A472 /* MyRoutineViewController.swift */,
 			);
 			name = ViewController;
 			sourceTree = "<group>";
@@ -431,10 +437,12 @@
 				18C363E7296D4D2700745400 /* CircleTextView.swift in Sources */,
 				188508132977B98D005B7BAB /* Routine.swift in Sources */,
 				18C363CF296D0C4F00745400 /* ListViewController.swift in Sources */,
+				18B7936229FBAEEC00C2A472 /* MyRoutineViewController.swift in Sources */,
 				18C6529929628DDD00EEB927 /* SceneDelegate.swift in Sources */,
 				18C363F5296D828400745400 /* UICollectionViewCell.swift in Sources */,
 				18A9B24D299B9231006C370D /* TextAddViewController.swift in Sources */,
 				18C363D7296D100200745400 /* MyInfoViewController.swift in Sources */,
+				18B7936029FB9D5E00C2A472 /* MyRoutineTableViewCell.swift in Sources */,
 				188508202977F5CF005B7BAB /* TodoManager.swift in Sources */,
 				18AB794C29C9BB680080A0DE /* UITaskTableViewCell.swift in Sources */,
 				18B6265E296F118F00BDAB50 /* CheckRoutineTableViewCell.swift in Sources */,

--- a/Routine.xcodeproj/project.pbxproj
+++ b/Routine.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1888996D29839DEE00F03EA9 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1888996C29839DEE00F03EA9 /* DateTests.swift */; };
 		1888996E2983A86900F03EA9 /* SnapKit-Dynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 18C363FF296DBCFE00745400 /* SnapKit-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		188BF94329724E3B0057C250 /* CreateRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */; };
+		18A369A22A18590700AEE9B9 /* RoutineSortViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A369A12A18590700AEE9B9 /* RoutineSortViewController.swift */; };
 		18A9B24B299B8195006C370D /* CountRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A9B24A299B8195006C370D /* CountRoutineTableViewCell.swift */; };
 		18A9B24D299B9231006C370D /* TextAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A9B24C299B9231006C370D /* TextAddViewController.swift */; };
 		18AB794C29C9BB680080A0DE /* UITaskTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AB794B29C9BB680080A0DE /* UITaskTableViewCell.swift */; };
@@ -95,6 +96,7 @@
 		1888996B2983902000F03EA9 /* RoutineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoutineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1888996C29839DEE00F03EA9 /* DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
 		188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoutineViewController.swift; sourceTree = "<group>"; };
+		18A369A12A18590700AEE9B9 /* RoutineSortViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSortViewController.swift; sourceTree = "<group>"; };
 		18A9B24A299B8195006C370D /* CountRoutineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountRoutineTableViewCell.swift; sourceTree = "<group>"; };
 		18A9B24C299B9231006C370D /* TextAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAddViewController.swift; sourceTree = "<group>"; };
 		18AB794B29C9BB680080A0DE /* UITaskTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITaskTableViewCell.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				188BF94229724E3B0057C250 /* CreateRoutineViewController.swift */,
 				18A9B24C299B9231006C370D /* TextAddViewController.swift */,
 				18B7936129FBAEEC00C2A472 /* MyRoutineViewController.swift */,
+				18A369A12A18590700AEE9B9 /* RoutineSortViewController.swift */,
 			);
 			name = ViewController;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				18B7936029FB9D5E00C2A472 /* MyRoutineTableViewCell.swift in Sources */,
 				188508202977F5CF005B7BAB /* TodoManager.swift in Sources */,
 				18AB794C29C9BB680080A0DE /* UITaskTableViewCell.swift in Sources */,
+				18A369A22A18590700AEE9B9 /* RoutineSortViewController.swift in Sources */,
 				18B6265E296F118F00BDAB50 /* CheckRoutineTableViewCell.swift in Sources */,
 				188300C2296FA71600E418DB /* UITableView.swift in Sources */,
 				188826B629796D6E00B6523A /* CreateRoutineViewControllerTests.swift in Sources */,

--- a/Routine/Cell/DailyCollectionViewCell.swift
+++ b/Routine/Cell/DailyCollectionViewCell.swift
@@ -82,6 +82,7 @@ final class DailyCollectionViewCell: UICollectionViewCell {
             print("date range over")
             return
         }
+        dailyLabel.text = date.weekDay?.rawValue
         dateCircleView.date = date
     }
     

--- a/Routine/CountRoutineTableViewCell.swift
+++ b/Routine/CountRoutineTableViewCell.swift
@@ -11,15 +11,7 @@ class CountRoutineTableViewCell: UITableViewCell {
         
     var routineCountTask: RoutineCountTask? = nil {
         didSet {
-            routineButton.setTitle(routineCountTask?.description, for: .normal)
-            guard let count = routineCountTask?.count,
-                  let goal = routineCountTask?.goal else { return }
-            routineCountTask?.isDone = goal <= count
-            guard let isDone = routineCountTask?.isDone else { return }
-            isDone ? setAll(color: UIColor.systemGray) : setAll(color: UIColor.black)
-            DispatchQueue.main.async {
-                self.descriptionLabel.text = "\(count)"
-            }
+            viewUpdate()
         }
     }
     
@@ -79,7 +71,7 @@ class CountRoutineTableViewCell: UITableViewCell {
         contentView.addSubview(plusButton)
         contentView.addSubview(minusButton)
     }
-    
+        
     private func autolayoutSetting() {
         
         routineButton.snp.makeConstraints { make in
@@ -117,10 +109,16 @@ class CountRoutineTableViewCell: UITableViewCell {
         minusButton.addGestureRecognizer(minusLongPress)
     }
     
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    private func viewUpdate() {
+        routineButton.setTitle(routineCountTask?.description, for: .normal)
+        guard let count = routineCountTask?.count,
+              let goal = routineCountTask?.goal else { return }
+        routineCountTask?.isDone = goal <= count
+        guard let isDone = routineCountTask?.isDone else { return }
+        isDone ? setAll(color: UIColor.systemGray) : setAll(color: UIColor.black)
+        DispatchQueue.main.async {
+            self.descriptionLabel.text = "\(count)"
+        }
     }
     
     func setAll(color: UIColor) {
@@ -161,8 +159,7 @@ class CountRoutineTableViewCell: UITableViewCell {
         self.routineCountTask?.count += 1
         guard let routineCountTask = routineCountTask else { return }
         delegate?.taskUpdate(task: routineCountTask)
-        let count = routineCountTask.count
-        let goal = routineCountTask.goal
+        viewUpdate()
     }
 
     @objc
@@ -184,8 +181,7 @@ class CountRoutineTableViewCell: UITableViewCell {
         self.routineCountTask?.count -= 1
         guard let routineCountTask = routineCountTask else { return }
         delegate?.taskUpdate(task: routineCountTask)
-        let count = routineCountTask.count
-        let goal = routineCountTask.goal
+        viewUpdate()
     }
     
     @objc

--- a/Routine/CountRoutineTableViewCell.swift
+++ b/Routine/CountRoutineTableViewCell.swift
@@ -12,10 +12,14 @@ class CountRoutineTableViewCell: UITableViewCell {
     var routineCountTask: RoutineCountTask? = nil {
         didSet {
             routineButton.setTitle(routineCountTask?.description, for: .normal)
-            guard let isDone = routineCountTask?.isDone,
-                  let count = routineCountTask?.count else { return }
+            guard let count = routineCountTask?.count,
+                  let goal = routineCountTask?.goal else { return }
+            routineCountTask?.isDone = goal <= count
+            guard let isDone = routineCountTask?.isDone else { return }
             isDone ? setAll(color: UIColor.systemGray) : setAll(color: UIColor.black)
-            descriptionLabel.text = "\(count)"
+            DispatchQueue.main.async {
+                self.descriptionLabel.text = "\(count)"
+            }
         }
     }
     
@@ -159,13 +163,6 @@ class CountRoutineTableViewCell: UITableViewCell {
         delegate?.taskUpdate(task: routineCountTask)
         let count = routineCountTask.count
         let goal = routineCountTask.goal
-        DispatchQueue.main.async {
-            if goal <= count {
-                self.descriptionLabel.textColor = .mainColor
-                self.routineCountTask?.isDone = true
-            }
-            self.descriptionLabel.text = "\(count)"
-        }
     }
 
     @objc
@@ -189,14 +186,6 @@ class CountRoutineTableViewCell: UITableViewCell {
         delegate?.taskUpdate(task: routineCountTask)
         let count = routineCountTask.count
         let goal = routineCountTask.goal
-        DispatchQueue.main.async {
-            if goal > count {
-                self.descriptionLabel.textColor = .black
-                self.routineCountTask?.isDone = false
-
-            }
-            self.descriptionLabel.text = "\(count)"
-        }
     }
     
     @objc

--- a/Routine/CreateRoutineViewController.swift
+++ b/Routine/CreateRoutineViewController.swift
@@ -205,6 +205,9 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         picker.preferredDatePickerStyle = .inline
         picker.tag = 2
         picker.backgroundColor = .white
+        if let date = Calendar.current.date(byAdding: .year, value: 100, to: Date()) {
+            picker.date = date
+        }
         return picker
     }()
     
@@ -274,90 +277,74 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
             make.top.equalTo(view.safeAreaLayoutGuide).inset(12)
             make.trailing.equalTo(removeButton.snp.leading).inset(-10)
         }
-        
         removeButton.snp.makeConstraints { make in
             make.top.equalTo(exitButton.snp.top)
             make.trailing.equalTo(view.safeAreaLayoutGuide).inset(10)
             make.width.equalTo(0)
         }
-        
         routineLabel.snp.makeConstraints { make in
             make.top.equalTo(exitButton.snp.bottom)
             make.leading.equalToSuperview().inset(10)
         }
-        
         routineTextField.snp.makeConstraints { make in
             make.top.equalTo(routineLabel.snp.bottom).inset(-12)
             make.centerX.equalToSuperview()
             make.width.equalTo(260)
             make.height.equalTo(36)
         }
-        
         workDailyLabel.snp.makeConstraints { make in
             make.top.equalTo(routineTextField.snp.bottom).inset(-32)
             make.leading.equalToSuperview().inset(10)
         }
-        
         workDailyStackView.snp.makeConstraints { make in
             make.top.equalTo(workDailyLabel.snp.bottom).inset(-12)
             make.leading.trailing.equalToSuperview().inset(12)
             make.height.equalTo(44)
         }
-        
         workDateLabel.snp.makeConstraints { make in
             make.top.equalTo(workDailyStackView.snp.bottom).inset(-32)
             make.leading.equalToSuperview().inset(10)
         }
-        
         startDateStackView.snp.makeConstraints { make in
             make.top.equalTo(workDateLabel.snp.bottom).inset(-16)
             make.leading.equalToSuperview().inset(10)
         }
-        
         endDateStackView.snp.makeConstraints { make in
             make.top.equalTo(startDateStackView.snp.bottom).inset(-16)
             make.leading.equalToSuperview().inset(10)
         }
-        
         notificationLabel.snp.makeConstraints { make in
             make.top.equalTo(endDateStackView.snp.bottom).inset(-32)
             make.leading.equalToSuperview().inset(10)
         }
-        
         notificationStackView.snp.makeConstraints { make in
             make.top.equalTo(notificationLabel.snp.bottom).inset(-16)
             make.leading.equalToSuperview().inset(10)
         }
-        
         notificationSwitch.snp.makeConstraints { make in
             make.centerY.equalTo(notificationStackView.snp.centerY)
             make.trailing.equalToSuperview().inset(12)
             make.width.equalTo(51)
             make.height.equalTo(30)
         }
-        
         typeLabel.snp.makeConstraints { make in
             make.top.equalTo(notificationStackView.snp.bottom).inset(-32)
             make.leading.equalToSuperview().inset(10)
         }
-        
         typeStackView.snp.makeConstraints { make in
             make.top.equalTo(typeLabel.snp.bottom).inset(-16)
             make.leading.equalToSuperview().inset(10)
             make.trailing.equalToSuperview().inset(22)
         }
-        
         goalLabel.snp.makeConstraints { make in
             make.top.equalTo(typeStackView.snp.bottom).inset(-32)
             make.leading.equalToSuperview().inset(10)
         }
-        
         goalTextField.snp.makeConstraints { make in
             make.top.equalTo(typeStackView.snp.bottom).inset(-32)
             make.width.equalTo(view.frame.width/2)
             make.centerX.equalToSuperview()
         }
-                
         doneButton.snp.makeConstraints { make in
             make.height.equalTo(44)
             make.leading.trailing.bottom.equalToSuperview()
@@ -377,6 +364,7 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
             }
         }
         startDatePicker.date = routine.startDate
+        startDateTextField.text = routine.startDate.dateToString
         if let endDate = routine.endDate {
             endDatePicker.date = endDate
             endDateTextField.backgroundColor = .mainColor
@@ -435,7 +423,6 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
     
     @objc
     func enabledAlert() {
-        
         if isAnimation { return }
         isAnimation = true
         let label = UILabel()
@@ -507,6 +494,12 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
     
     @objc
     func setEndDatePicker() {
+        if startDatePicker.date > Date() {
+            endDatePicker.date = startDatePicker.date
+        } else {
+            endDatePicker.date = Date()
+        }
+        endDatePicker.date = startDatePicker.date > Date() ? startDatePicker.date : Date()
         endDateTextField.text = endDatePicker.date.dateToString
         endDateTextField.backgroundColor = .mainColor
         endDateTextField.textColor = .black
@@ -628,6 +621,9 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
     
     @objc
     func noSetting() {
+        if let date = Calendar.current.date(byAdding: .year, value: 100, to: Date()) {
+            endDatePicker.date = date
+        }
         endDateTextField.textColor = .white
         endDateTextField.text = "설정안함"
         endDateTextField.backgroundColor = .secondaryColor
@@ -721,6 +717,7 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         let isRoutineTitleAmend = routine.description != updateRoutine.description
         let isDateAmend = routine.startDate != updateRoutine.startDate || routine.endDate != updateRoutine.endDate
         let isNotificationAmend = routine.notificationTime != updateRoutine.notificationTime
+        print(isRoutineTitleAmend, isDateAmend, isNotificationAmend)
         let isAmend = isRoutineTitleAmend != false || isDateAmend != false || isNotificationAmend != false
         return isAmend
     }
@@ -751,7 +748,6 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
             return
         }
         guard let newRoutine = createRoutine() else {
-            //TODO: 루틴 텍스트를 작성하지 않은 경우 에러 처리
             print("routine is nil")
             return
         }
@@ -764,7 +760,10 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         guard let description = routineTextField.text else { return nil }
         let dayOfWeeks = selectedDayOfWeeks()
         let startDate = fetchDate(to: startDateStackView) ?? Date()
-        let endDate = fetchDate(to: endDateStackView)
+        var endDate: Date? = nil
+        if let endFetchDate = fetchDate(to: endDateStackView) {
+            endDate = endFetchDate.lastTimeDate
+        }
         let notificationTime = selectedNotificationTime()
         let type = selectedType()
         switch type {
@@ -782,8 +781,11 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         guard var routine = routine,
               let description = routineTextField.text else { return nil }
         let dayOfWeeks = selectedDayOfWeeks()
-        let startDate = fetchDate(to: startDateStackView) ?? Date()
-        let endDate = fetchDate(to: endDateStackView)
+        let startDate = fetchDate(to: startDateStackView) ?? Date().removeTimeDate
+        var endDate: Date? = nil
+        if let endFetchDate = fetchDate(to: endDateStackView) {
+            endDate = endFetchDate.lastTimeDate
+        }
         let notificationTime = selectedNotificationTime()
         routine.description = description
         routine.dayOfWeek = dayOfWeeks
@@ -839,11 +841,7 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         formatter.dateFormat = "yyyy년 MM월 dd일"
         if let dateTextField = stackView.arrangedSubviews.compactMap({ $0 as? UITextField }).first,
            let dateString = dateTextField.text {
-            let gmtDate = formatter.date(from: dateString)
-            guard let gmtDate = gmtDate else { return nil }
-            let secondsFromGMT = TimeZone.autoupdatingCurrent.secondsFromGMT(for: gmtDate)
-            guard let localizedDate = gmtDate.addingTimeInterval(TimeInterval(secondsFromGMT)).removeTimeStamp else { return nil }
-            return localizedDate
+            return formatter.date(from: dateString)
         }
         return nil
     }
@@ -874,14 +872,18 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
     @objc
     func dateFormatting(datePicker: UIDatePicker) {
         var textField = UITextField()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 MM월 dd일"
         if datePicker.tag == 1 {
             if startDatePicker.date > endDatePicker.date {
                 let alert = UIAlertController(title: nil, message: "시작일과 종료일이 올바르지 않게 입력되었습니다.", preferredStyle: .alert)
                 let okAction = UIAlertAction(title: "확인", style: .default)
                 alert.addAction(okAction)
                 present(alert, animated: false)
-                startDatePicker.date = endDatePicker.date
-                startDateTextField.text = endDatePicker.date.dateToString
+                if let startDateText = startDateTextField.text,
+                   let beforeDate = dateFormatter.date(from: startDateText) {
+                    startDatePicker.date = beforeDate
+                }
                 return
             }
             textField = startDateTextField
@@ -893,8 +895,10 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
                 let okAction = UIAlertAction(title: "확인", style: .default)
                 alert.addAction(okAction)
                 present(alert, animated: false)
-                endDatePicker.date = startDatePicker.date
-                endDateTextField.text = endDatePicker.date.dateToString
+                if let endDateText = endDateTextField.text,
+                   let beforeDate = dateFormatter.date(from: endDateText) {
+                    endDatePicker.date = beforeDate
+                }
                 return
             }
             textField.text = endDatePicker.date.dateToString

--- a/Routine/CreateRoutineViewController.swift
+++ b/Routine/CreateRoutineViewController.swift
@@ -392,20 +392,20 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
             }
             goalTextField.text = "\(countRoutine.goal)"
             goalAreaVisible()
-        } else if let _ = routine as? CheckRoutine {
-            typeStackView.arrangedSubviews.forEach { view in
-                guard let button = view as? UIButton,
-                      let text = button.titleLabel?.text else { return }
-                if text == RoutineType.check.rawValue {
-                    button.isSelected = true
-                    typeButtonClick(button)
-                }
-            }
         } else if let _ = routine as? TextRoutine {
             typeStackView.arrangedSubviews.forEach { view in
                 guard let button = view as? UIButton,
                       let text = button.titleLabel?.text else { return }
                 if text == RoutineType.text.rawValue {
+                    button.isSelected = true
+                    typeButtonClick(button)
+                }
+            }
+        }  else {
+            typeStackView.arrangedSubviews.forEach { view in
+                guard let button = view as? UIButton,
+                      let text = button.titleLabel?.text else { return }
+                if text == RoutineType.check.rawValue {
                     button.isSelected = true
                     typeButtonClick(button)
                 }
@@ -768,7 +768,7 @@ final class CreateRoutineViewController: UIViewController, UNUserNotificationCen
         let type = selectedType()
         switch type {
         case .check:
-            return CheckRoutine(description: description, dayOfWeek: dayOfWeeks, startDate: startDate, endDate: endDate, notificationTime: notificationTime)
+            return Routine(description: description, dayOfWeek: dayOfWeeks, startDate: startDate, endDate: endDate, notificationTime: notificationTime)
         case .text:
             return TextRoutine(description: description, dayOfWeek: dayOfWeeks, startDate: startDate, endDate: endDate, notificationTime: notificationTime)
         case .count:

--- a/Routine/Extension/Date.swift
+++ b/Routine/Extension/Date.swift
@@ -9,9 +9,16 @@ import Foundation
 
 extension Date {
     
-    var removeTimeStamp: Date? {
-        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: self)) else { return nil }
+    var removeTimeDate: Date {
+        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: self)) else { return self }
         return date
+    }
+    
+    var lastTimeDate: Date {
+        let calendar = Calendar.current
+        guard let addDate = calendar.date(byAdding: .day, value: 1, to: self),
+              let lastTimeDate = calendar.date(byAdding: .second, value: -1, to: addDate) else { return self }
+        return lastTimeDate
     }
     
     var timeToString: String {
@@ -80,7 +87,7 @@ extension Date {
         let dayOfWeek = calendar.component(.weekday, from: date)
         let weekdays = calendar.range(of: .weekday, in: .weekOfMonth, for: date) ?? Range(uncheckedBounds: (lower: 1, upper: 8))
         let days = (weekdays.lowerBound ..< weekdays.upperBound)
-            .compactMap { calendar.date(byAdding: .day, value: $0 - dayOfWeek, to: date)?.removeTimeStamp }
+            .compactMap { calendar.date(byAdding: .day, value: $0 - dayOfWeek, to: date)?.removeTimeDate }
         return days
     }
     

--- a/Routine/ListViewController.swift
+++ b/Routine/ListViewController.swift
@@ -66,7 +66,7 @@ final class ListViewController: UIViewController {
     }()
     private var todayIndex = 0
     private var beginPositionX: CGFloat = 0.0
-    private var selectedDate = Date().removeTimeStamp! {
+    private var selectedDate = Date() {
         didSet {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy년 M월"
@@ -163,7 +163,7 @@ final class ListViewController: UIViewController {
         dailyCollectionView.selectItem(at: todayIndexPath, animated: true, scrollPosition: .centeredHorizontally)
         guard let date = (dailyCollectionView.cellForItem(at: todayIndexPath) as? DailyCollectionViewCell)?.date else { return }
         selectedDate = date
-        RoutineManager.update = listTableView.reloadData
+        RoutineManager.viewUpdates.append(listTableView.reloadData)
     }
     
     private func tableViewSetting() {

--- a/Routine/ListViewController.swift
+++ b/Routine/ListViewController.swift
@@ -163,7 +163,7 @@ final class ListViewController: UIViewController {
         dailyCollectionView.selectItem(at: todayIndexPath, animated: true, scrollPosition: .centeredHorizontally)
         guard let date = (dailyCollectionView.cellForItem(at: todayIndexPath) as? DailyCollectionViewCell)?.date else { return }
         selectedDate = date
-        RoutineManager.viewUpdates.append(listTableView.reloadData)
+        RoutineManager.arrayViewUpdates.append(listTableView.reloadData)
     }
     
     private func tableViewSetting() {
@@ -183,7 +183,18 @@ final class ListViewController: UIViewController {
     }
     
     private func addAction() {
+        sortButton.addTarget(self, action: #selector(routineSort), for: .touchUpInside)
+        filterButton.addTarget(self, action: #selector(routineFilter), for: .touchUpInside)
         listAddButton.addTarget(self, action: #selector(listAdd), for: .touchUpInside)
+    }
+    
+    @objc
+    func routineSort() {
+        
+    }
+    
+    @objc func routineFilter() {
+        
     }
     
     @objc

--- a/Routine/MyRoutineTableViewCell.swift
+++ b/Routine/MyRoutineTableViewCell.swift
@@ -1,0 +1,85 @@
+//
+//  MyRoutineTableViewCell.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/04/28.
+//
+
+import UIKit
+import SnapKit
+
+class MyRoutineTableViewCell: UITableViewCell {
+    
+    var routine: Routine? = nil {
+        didSet {
+            routineUpdate()
+        }
+    }
+    
+    private let myRoutineLabel: UILabel = {
+        let lb = UILabel()
+        lb.font = .systemFont(ofSize: 18, weight: .bold)
+        lb.text = "test"
+        lb.textAlignment = .center
+        lb.layer.borderColor = UIColor.systemGray.cgColor
+        lb.layer.borderWidth = 0.5
+        return lb
+    }()
+    
+    private let countLabel: UILabel = {
+        let lb = UILabel()
+        lb.font = .systemFont(ofSize: 18, weight: .regular)
+        lb.text = "카운트: 0"
+        lb.textAlignment = .center
+        lb.layer.borderColor = UIColor.systemGray.cgColor
+        lb.layer.borderWidth = 0.5
+        return lb
+    }()
+    
+    private let goalRateLabel: UILabel = {
+        let lb = UILabel()
+        lb.font = .systemFont(ofSize: 18, weight: .regular)
+        lb.text = "달성률: 0%"
+        lb.textAlignment = .center
+        lb.layer.borderColor = UIColor.systemGray.cgColor
+        lb.layer.borderWidth = 0.5
+        return lb
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(myRoutineLabel)
+        contentView.addSubview(countLabel)
+        contentView.addSubview(goalRateLabel)
+        contentView.backgroundColor = .secondaryColor
+        autoLayoutSetting()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func autoLayoutSetting() {
+        myRoutineLabel.snp.makeConstraints { make in
+            make.leading.centerY.height.equalToSuperview()
+            make.width.equalTo(contentView.snp.width).dividedBy(3)
+        }
+        countLabel.snp.makeConstraints { make in
+            make.leading.equalTo(myRoutineLabel.snp.trailing)
+            make.center.height.equalToSuperview()
+            make.width.equalTo(contentView.snp.width).dividedBy(3)
+        }
+        goalRateLabel.snp.makeConstraints { make in
+            make.trailing.centerY.height.equalToSuperview()
+            make.width.equalTo(contentView.snp.width).dividedBy(3)
+        }
+    }
+    
+    private func routineUpdate() {
+        guard let routine = routine else { return }
+        myRoutineLabel.text = routine.description
+        countLabel.text = "\(routine.goalTask.count)"
+        goalRateLabel.text = "\(routine.goalRate)"
+    }
+
+}

--- a/Routine/MyRoutineTableViewCell.swift
+++ b/Routine/MyRoutineTableViewCell.swift
@@ -78,8 +78,8 @@ class MyRoutineTableViewCell: UITableViewCell {
     private func routineUpdate() {
         guard let routine = routine else { return }
         myRoutineLabel.text = routine.description
-        countLabel.text = "\(routine.goalTask.count)"
-        goalRateLabel.text = "\(routine.goalRate)"
+        countLabel.text = "\(routine.goalTask.count)회"
+        goalRateLabel.text = "\(routine.goalRate)%"
     }
 
 }

--- a/Routine/MyRoutineViewController.swift
+++ b/Routine/MyRoutineViewController.swift
@@ -1,0 +1,73 @@
+//
+//  MyRoutineViewController.swift
+//  Routine
+//
+//  Created by 김도현 on 2023/04/28.
+//
+
+import UIKit
+import SnapKit
+
+class MyRoutineViewController: UIViewController {
+    
+    private let myRoutineTableView: UITableView = {
+        let tb = UITableView()
+        tb.rowHeight = 80
+        return tb
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.title = "나의 루틴"
+        view.addSubview(myRoutineTableView)
+        autoLayoutSetting()
+        tableViewSetting()
+    }
+    
+    private func autoLayoutSetting() {
+        myRoutineTableView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.leading.trailing.bottom.equalToSuperview().inset(16)
+        }
+    }
+    
+    private func tableViewSetting() {
+        myRoutineTableView.register(MyRoutineTableViewCell.self)
+        myRoutineTableView.delegate = self
+        myRoutineTableView.dataSource = self
+        RoutineManager.viewUpdates.append(myRoutineTableView.reloadData)
+    }
+}
+
+extension MyRoutineViewController: UITableViewDelegate, UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return RoutineManager.routines.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 16
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let routine = RoutineManager.routines[indexPath.section]
+        let myRoutineCell = tableView.dequeueReusableCell(MyRoutineTableViewCell.self, for: indexPath)
+        myRoutineCell.layer.borderWidth = 0.5
+        myRoutineCell.layer.borderColor = UIColor.systemGray.cgColor
+        myRoutineCell.layer.cornerRadius = 5
+        myRoutineCell.clipsToBounds = true
+        myRoutineCell.routine = routine
+        return myRoutineCell
+    }
+    
+}

--- a/Routine/MyRoutineViewController.swift
+++ b/Routine/MyRoutineViewController.swift
@@ -35,7 +35,7 @@ class MyRoutineViewController: UIViewController {
         myRoutineTableView.register(MyRoutineTableViewCell.self)
         myRoutineTableView.delegate = self
         myRoutineTableView.dataSource = self
-        RoutineManager.viewUpdates.append(myRoutineTableView.reloadData)
+        RoutineManager.arrayViewUpdates.append(myRoutineTableView.reloadData)
     }
 }
 

--- a/Routine/Routine.swift
+++ b/Routine/Routine.swift
@@ -45,7 +45,7 @@ extension Routine {
             task.isDone
         }
     }
-    var goalRate: Double {
+    var goalRate: Int {
         var firstAndLastWeekDays = 0 // 첫째주와 마지막주의 날짜 갯수를 표시해줄 변수
         var allTask = 0 // 기간동안 해야할 모든 작업들의 갯수를 표시해줄 변수
         let fromDate = startDate
@@ -56,13 +56,13 @@ extension Routine {
         }
         guard let fromDateWeek = fromDate.weekDay,
               let toDateWeek = toDate.weekDay,
-              let differnceDay = Calendar.current.dateComponents([.day], from: fromDate, to: toDate).day else { return 0.0 }
+              let differnceDay = Calendar.current.dateComponents([.day], from: fromDate, to: toDate).day else { return 0 }
         //taskTerm: 작업기간
         let taskTerm = differnceDay + 1
         
         let allCase = DayOfWeek.allCases
         guard let fromDateIndex = allCase.firstIndex(of: fromDateWeek),
-              let toDateIndex = allCase.firstIndex(of: toDateWeek) else { return 0.0 }
+              let toDateIndex = allCase.firstIndex(of: toDateWeek) else { return 0 }
         
         // 작업기간이 한주에 모두 포함되어 있는 경우
         if taskTerm < 7 && fromDateIndex < toDateIndex {
@@ -83,10 +83,9 @@ extension Routine {
                 self.dayOfWeek.contains(allCaseWeek)
             }.count * middleTerm
         }
-        print(differnceDay, allTask, goalTask.count)
         let goalRate = round((Double(goalTask.count) / Double(allTask)) * 1000) / 10
         
-        return goalRate
+        return Int(goalRate)
     }
     mutating func allDoneTaskUpdate() {
         for index in 0..<myTaskList.count {

--- a/Routine/RoutineManager.swift
+++ b/Routine/RoutineManager.swift
@@ -9,20 +9,22 @@ import Foundation
 import UserNotifications
 
 class RoutineManager {
-    static var routines: [Routine] = [] {
-        didSet {
-            RoutineManager.viewUpdates.forEach { viewUpdate in
-                viewUpdate()
-            }
-        }
-    }
-    static var viewUpdates: [() -> Void] = []
+    static var routines: [Routine] = []
+    static var arrayViewUpdates: [() -> Void] = []
+    
     var routineCount: Int {
         return RoutineManager.routines.count
     }
     
+    static func viewUpdate() {
+        RoutineManager.arrayViewUpdates.forEach { viewUpdate in
+            viewUpdate()
+        }
+    }
+    
     static func create(_ routine: Routine) {
         RoutineManager.routines.append(routine)
+        viewUpdate()
     }
     
     static func append(_ task: RoutineTask) {
@@ -36,6 +38,7 @@ class RoutineManager {
             return
         }
         RoutineManager.routines[index].myTaskList.append(task)
+        viewUpdate()
     }
     
     static func update(_ task: RoutineTask) {
@@ -49,6 +52,7 @@ class RoutineManager {
             return
         }
         RoutineManager.routines[routineIndex].myTaskList[taskIndex] = task
+        viewUpdate()
     }
     
     static func update(_ routine: Routine) {
@@ -56,6 +60,7 @@ class RoutineManager {
         //MARK: 완료한 루틴 이전의 내용도 바꿀것인지 현재 내용만 바꿀것인지, 특정날 이후로만 바꿀 것인지 선택 가능하게 하기
         RoutineManager.routines[routineIndex] = routine
         RoutineManager.routines[routineIndex].allDoneTaskUpdate()
+        viewUpdate()
     }
     
     static func fetch(_ identifier: UUID) -> Routine? {
@@ -76,15 +81,17 @@ class RoutineManager {
         for index in 0..<RoutineManager.routines.count {
             if let routineTask = RoutineManager.routines[index].myTaskList.first(where: { calendar.isDate(date, equalTo: $0.taskDate, toGranularity: .day) }) {
                 tasks.append(routineTask)
-            } else if let newRoutineTask = RoutineManager.routines[index].createTask(date: date) {
+            } else if let newRoutineTask = RoutineManager.routines[index].getTask(date: date) {
                 tasks.append(newRoutineTask)
             }
         }
+        viewUpdate()
         return tasks
     }
     
     static func remove(routineIdentifier: UUID) {
         RoutineManager.routines.removeAll { $0.identifier == routineIdentifier }
+        viewUpdate()
     }
     
     func remove(routineTask: RoutineTask) {

--- a/Routine/RoutineManager.swift
+++ b/Routine/RoutineManager.swift
@@ -11,10 +11,12 @@ import UserNotifications
 class RoutineManager {
     static var routines: [Routine] = [] {
         didSet {
-            RoutineManager.update()
+            RoutineManager.viewUpdates.forEach { viewUpdate in
+                viewUpdate()
+            }
         }
     }
-    static var update: () -> Void = {}
+    static var viewUpdates: [() -> Void] = []
     var routineCount: Int {
         return RoutineManager.routines.count
     }

--- a/Routine/TabBarController.swift
+++ b/Routine/TabBarController.swift
@@ -24,7 +24,7 @@ class TabBarController: UITabBarController {
     
     private func viewControllerSetting() {
         let vc1 = UINavigationController(rootViewController: ListViewController(viewModel: ListViewModel()))
-        let vc2 = UINavigationController(rootViewController: MyInfoViewController())
+        let vc2 = UINavigationController(rootViewController: MyRoutineViewController())
         let vc3 = UINavigationController(rootViewController: SettingViewController())
 
         vc1.title = "목록"

--- a/RoutineTests/ListViewModelTests.swift
+++ b/RoutineTests/ListViewModelTests.swift
@@ -24,7 +24,7 @@ final class TaskListViewModelTests: XCTestCase {
     }
     
     func testRoutine_추가시_정보가_저장됨() {
-        let routine = CheckRoutine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date())
+        let routine = Routine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date())
         sut.create(routine: routine)
         if let fetchRoutine = sut.fetch(routineIdentifier: routine.identifier) {
             XCTAssertEqual(fetchRoutine.identifier, routine.identifier, "루틴이 저장되지 않음")
@@ -46,7 +46,7 @@ final class TaskListViewModelTests: XCTestCase {
     }
     
     func test루틴_할일_성공시_저장() {
-        let routine = CheckRoutine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date())
+        let routine = Routine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date())
         sut.create(routine: routine)
         let routineTask = RoutineTextTask(routine: routine, text: "TestTask", taskDate: Date())
         sut.append(routinTask: routineTask)
@@ -66,9 +66,9 @@ final class TaskListViewModelTests: XCTestCase {
         }
         
         var routines: [Routine] = []
-        routines.append(CheckRoutine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date()))
-        routines.append(CheckRoutine(description: "title", dayOfWeek: [.mon, .wed, .fir], startDate: Date()))
-        routines.append(CheckRoutine(description: "title", dayOfWeek: [.tue, .thu], startDate: Date()))
+        routines.append(Routine(description: "title", dayOfWeek: DayOfWeek.allCases, startDate: Date()))
+        routines.append(Routine(description: "title", dayOfWeek: [.mon, .wed, .fir], startDate: Date()))
+        routines.append(Routine(description: "title", dayOfWeek: [.tue, .thu], startDate: Date()))
         
         routines.forEach { routine in
             sut.create(routine: routine)


### PR DESCRIPTION
## 제목 Routine 프로토콜을 클래스로 변경함

## 작업내용
Routine을 프로토콜에서 클래스로 변경
CheckRoutine이 Routine 클래스에 합쳐짐
TextRoutine과 CountRoutine 은 Routine을 상속받고 이름은 그대로 사용
CheckRoutineTask, TextRoutineTask, CountRoutineTask또한 같은 방식으로 변경

구조체였던 Routine과 RoutineTask를 class로 바꾼 이유
일단 구조체로 하기에 적절하지 않은 참조타입의 값들을 많이 가지고 있음
또한 루틴 전체에 새로운 정보를 담으려고하면 체크, 카운트, 텍스트 루틴에 각자 추가해야하는 번거로움
그리고 또 다른타입의 루틴을 만드려고 할 경우 했던 작업을 반복해야하는 일이 많아짐